### PR TITLE
Add can-wizard proyect

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ All kind of HW like CAN bus USB2CAN dongles, loggers, sniffers, adapters, etc.
 * [ESP32_OBD2_Emulator](https://github.com/MagnusThome/ESP32_OBD2_Emulator) - Simple OBD2 car emulator which runs on ESP32-S3 (replies to all OBD2 requests with dummy data).
 * [RejsaCAN-ESP32](https://github.com/MagnusThome/RejsaCAN-ESP32) - ESP32-S3 board with CAN interface.
 * [RejsaCAN-ESP32-C6](https://github.com/MagnusThome/RejsaCAN-ESP32/tree/main/Code%20Examples/RejsaCAN%20v6.x%20-%20ESP32-C6%20-%20DUAL%20CAN%20self%20test) - Example code that is tested and runs on the new ESP32-C6 that has TWO built in CAN controllers.
+* [CAN-wizard](https://github.com/okhsunrog/can_wizard) - CAN bus sniffer on esp32/esp32-c3 + SN65HVD230. Is developed using ESP-IDF and implement serial control console.
 
 
 ### SBC


### PR DESCRIPTION
CAN Wizard
CAN Wizard is a project designed for communication using the CAN (Controller Area Network) protocol, primarily targeted at embedded systems utilizing the ESP32 microcontroller family. This project is developed using ESP-IDF and supports ESP32-C3, allowing flexible development for different use cases.

Features
- CAN Communication: Implements CAN communication protocols, enabling data exchange between devices over a CAN bus.
- File System Integration: Includes file system operations for handling configuration or logging.
- Custom serial Console: A custom serial console implementation for interacting with the system and issuing commands.
- Modular Design: Organized in components for easier maintenance and scalability, including linked lists and command utilities.