### PR TITLE
Add BlackFlag ECU - CAN bus diagnostics toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ _SAE J2534 Standard_
 * [j2534-tcp](https://github.com/brandonros/j2534-tcp) - Virtual J2534 driver over TCP/IP.
 * [SharpWrap2534](https://github.com/MEAT-Inc/SharpWrap2534) - The Ultimate J2534 Wrapper Suite.
 * [gocanflasher](https://github.com/roffe/gocanflasher) - Trionic 5/7/8 CANbus flasher with J2534 support.
+* [BlackFlag ECU](https://github.com/bad-antics/blackflag-ecu) - GTK4 automotive diagnostics toolkit with CAN bus analysis, J2534 passthru support, OBD-II scanning, and ECU flash capabilities. Built with Python and libadwaita.
 
 
 ## Utils


### PR DESCRIPTION
## Add BlackFlag ECU to J2534 Tools

**Project:** [BlackFlag ECU](https://github.com/bad-antics/blackflag-ecu)

**Description:** GTK4 automotive diagnostics toolkit with CAN bus analysis, J2534 passthru support, OBD-II scanning, and ECU flash capabilities. Built with Python and libadwaita.

### Features
- CAN bus traffic analysis and monitoring
- SAE J2534 passthru interface support
- OBD-II diagnostic scanning
- ECU flash read/write capabilities
- Modern GTK4/libadwaita desktop interface
- Built with Python for extensibility

### Placement
Added to the **J2534 Tools** section, as the tool provides J2534 passthru support alongside CAN bus diagnostics and ECU flashing — fitting naturally with the existing J2534-focused entries.

### Checklist
- [x] Entry follows the existing list format
- [x] Link is valid and points to an active repository
- [x] Description is concise and informative
- [x] Placed in the appropriate section