### PR TITLE
Add CANviz - browser-based CAN/J1939/CANopen analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ _SAE J2534 Standard_
 * [EcuBus-Pro](https://github.com/ecubus/EcuBus-Pro) - A powerful automotive ECU development tool. UDS, CAN-TP, DOIP, LIN , Script(TS) like CAPL.
 * [Novo Bus Analyzer](https://github.com/reymor/novobusanalyzer) - Fork of BUSMASTER (BUSMASTER is an Open Source Software tool to simulate, analyze and test data bus systems such as CAN).
 * [bootCAN](https://github.com/friessssss/bootCAN) - Allows monitoring, tracing, and plotting of messages, as well as .SYM decoding and message transmitting.
+* [CANviz](https://github.com/Chanchaldhiman/CANviz) - Browser-based CAN bus analyzer with J1939 and CANopen CiA 301/402 passive decode. Installs via pip, no native app required. Works with almost any CAN harware including low cost ones.
 
 
 ### TUI Tools


### PR DESCRIPTION
CANviz is a browser-based CAN analyzer that installs via pip and requires no native application. It passively decodes J1939 (BAM reassembly, DM1 faults, address claim) and CANopen (NMT, EMCY, SDO pairing, CiA 402 drive state without EDS). Works with Candlelight firmware devices and slcan hardware.